### PR TITLE
Update psnpricealert.py

### DIFF
--- a/psnpricealert.py
+++ b/psnpricealert.py
@@ -2,9 +2,19 @@ import json
 import sys
 import logging
 
-logging.basicConfig( 
-    filename="psnpricealert.log", 
-    level = logging.DEBUG, 
+version = sys.version_info[0]
+# import only once
+if version == 3:
+    from urllib.request import urlopen
+    from urllib.parse import quote
+elif version == 2:
+    import urllib
+else:
+    version == False
+
+logging.basicConfig(
+    filename="psnpricealert.log",
+    level = logging.DEBUG,
     format = "%(asctime)s [%(levelname)-8s] %(message)s",
     filemode = "w")
 
@@ -12,12 +22,6 @@ apiRoot = "https://store.sonyentertainmentnetwork.com/store/api/chihiro/00_09_00
 
 def getJsonResponse(url):
     # Python 2.x or 3.x support
-    version = sys.version_info[0]
-    if version == 3:
-        from urllib.request import urlopen
-    elif version == 2:
-        import urllib
-
     if version == 3:
         response = urlopen(url)
         enc = response.read().decode('utf-8')
@@ -25,32 +29,46 @@ def getJsonResponse(url):
     elif version == 2:
         response = urllib.urlopen(url)
         data = json.load(response)
-        return data
+    else:
+        return False
+    return data
 
 def checkWishPrice(cid, store, wishPrice):
-
     url = apiRoot + "/container/"+store+"/19/"+cid+"?size=99999"
-
     data = getJsonResponse(url)
-    print(data['default_sku']['entitlements'][0]['name'].encode("utf-8") + " - " + data['default_sku']['display_price'].encode("utf-8"))  
 
+    if data == False:
+        print("Python 2.x or 3.x required.")
+        sys.exit(0)
+
+    print(data['default_sku']['entitlements'][0]['name'] + " - " + data['default_sku']['display_price'])
     currentPrice = float(data['default_sku']['price']) / 100
 
     if (currentPrice > wishPrice):
-    	print "Wish price %.2f not yet matched %.2f, exiting" %(wishPrice, currentPrice)
+        if version == 3:
+            print("Wish price {0:.2f} does not yet match {1:.2f}, exiting".format(wishPrice, currentPrice))
+        else:
+    	    print("Wish price %.2f does not yet match %.2f, exiting" %(wishPrice, currentPrice))
     else:
-    	print "Wish price %.2f matched. Is now: %.2f" %(wishPrice, currentPrice)
+        if version == 3:
+            print("Wish price %{0:.2f} matched. Is now: %{1:.2f}".format(wishPrice, currentPrice))
+        else:
+            print("Wish price %.2f matched. Is now: %.2f" %(wishPrice, currentPrice))
     	#TODO send alert
         raise Exception("Alert sending not yet implemented")
 
 def getCidForName(name, store):
-
-    url = apiRoot+"/bucket_search/"+store+"/19/"+name+"?size=99999&start=0"
+    # encode name for HTTP request
+    if version == 3:
+        encName = quote(name)
+    else:
+        encName = urllib.quote(name)
+    url = apiRoot+"/bucket_search/"+store+"/19/"+encName+"?size=99999&start=0"
     data = getJsonResponse(url)
-
     links = data['categories']['games']['links']
 
     if (len(links) > 1):
+        # TODO: Let them select from list of results for proper CID?
         logging.error("Found more than one entry for name " + name)
         for link in links:
             logging.debug ("Found: " + link['default_sku']['entitlements'][0]['name'] + " - " + link['default_sku']['entitlements'][0]['id'])


### PR DESCRIPTION
- do our version-specific imports only once vs in getJsonResponse(url)
- return data for both versions in getJsonResponse(url)
- quit if not Python 2.x or 3.x (may not be necessary, just added it in case)
- print out price found without the use of .encode("utf-8") - line 44
  - encodes to Bytes and then we cannot use String concatenation (+) on the Bytes
- add match/no match message for 3.x (slightly different format)
- encode the name we are using for CID search prior to HTTP request (was generating Bad Requests)
